### PR TITLE
Switch to ElevenLabs TTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment configuration
+PORT=3000
+BASE_URL=http://localhost:3000
+GROQ_API_KEY=your-groq-key
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your-twilio-auth-token
+TWILIO_PHONE_NUMBER=+11234567890
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+ELEVENLABS_API_KEY=your-elevenlabs-api-key
+ELEVENLABS_VOICE_ID=voice-id

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ app.get("/test-tts", async (req, res) => {
   const text =
     req.query.text ||
     "नमस्ते, यह एक पूर्ण परीक्षण संदेश है ताकि आप सुन सकें कि आवाज़ कैसी निकलती है।";
-  const url = await synthesizeIndianEnglish(text, "test-tts", false);
+  const url = await synthesizeIndianEnglish(text, "test-tts");
   res.json({ url });
 });
 
@@ -32,7 +32,7 @@ app.get("/test-ssml", async (req, res) => {
   const sessionId = "TEST";
   initSession(sessionId, { name: "Test User", description: "Demo" });
   const { ssml } = await handleUserMessage(sessionId, "");
-  const url = await synthesizeIndianEnglish(ssml, "test-ssml", true);
+  const url = await synthesizeIndianEnglish(ssml, "test-ssml");
   endSession(sessionId);
   res.json({ url });
 });
@@ -48,8 +48,7 @@ app.post(
 
     try {
       let resp,
-        content,
-        isSsml = false;
+        content;
       if (!SpeechResult) {
         const contact = await prisma.contact.findUnique({
           where: { phone: To },
@@ -60,11 +59,9 @@ app.post(
         });
         resp = await handleUserMessage(CallSid, "");
         content = resp.ssml;
-        isSsml = true;
       } else {
         resp = await handleUserMessage(CallSid, SpeechResult);
         content = resp.ssml;
-        isSsml = content.trim().startsWith("<speak>");
       }
 
       const shouldHangup = resp.toolCalls.some((c) => c.name === "hangup");
@@ -73,7 +70,6 @@ app.post(
       const audioUrl = await synthesizeIndianEnglish(
         content,
         `${CallSid}_${SpeechResult ? "resp" : "greet"}`,
-        isSsml,
       );
 
       // === NEW: allow barge-in during playback ===

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/storage": "^7.16.0",
-        "@google-cloud/text-to-speech": "^6.1.0",
+        "axios": "^1.9.0",
         "@langchain/groq": "^0.2.2",
         "@prisma/client": "^6.8.1",
         "dotenv": "^16.5.0",
@@ -262,20 +262,8 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@google-cloud/text-to-speech": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/text-to-speech/-/text-to-speech-6.1.0.tgz",
-      "integrity": "sha512-QP8ESj0/QWyWDVI2wD0azoToxeBJ86IENajTTxgWkSXAki474qwv4hZgt5AHCtMJWHmWG5OnVNHzah5+zfbTlg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-gax": "^5.0.1-rc.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
+    
     "node_modules/@grpc/grpc-js": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
@@ -350,9 +338,6 @@
         "groq-sdk": "^0.19.0",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.22.5"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "peerDependencies": {
         "@langchain/core": ">=0.2.21 <0.4.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "type": "commonjs",
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",
-    "@google-cloud/text-to-speech": "^6.1.0",
+    "axios": "^1.9.0",
     "@langchain/groq": "^0.2.2",
     "@prisma/client": "^6.8.1",
     "dotenv": "^16.5.0",

--- a/ttsService.js
+++ b/ttsService.js
@@ -1,29 +1,39 @@
 // ttsService.js
-const { TextToSpeechClient } = require("@google-cloud/text-to-speech");
+const axios = require("axios");
 const { Storage } = require("@google-cloud/storage");
 
-const ttsClient = new TextToSpeechClient();
 const storage = new Storage();
 const BUCKET = "kaz_ai";
 
-// Generates speech using an Indian-accented English voice
-async function synthesizeIndianEnglish(textOrSsml, filename, isSsml = false) {
-  // 1) TTS request
-  const input = isSsml ? { ssml: textOrSsml } : { text: textOrSsml };
-  const [response] = await ttsClient.synthesizeSpeech({
-    input,
-    voice: {
-      languageCode: "en-IN",
-      name: "en-IN-Standard-E",
-      ssmlGender: "FEMALE",
+// Generates speech using the ElevenLabs API and stores the MP3 in GCS
+function stripSsml(ssml) {
+  return ssml.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+async function synthesizeIndianEnglish(text, filename) {
+  const apiKey = process.env.ELEVENLABS_API_KEY;
+  const voiceId = process.env.ELEVENLABS_VOICE_ID;
+  const url = `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`;
+
+  const payload = { text: stripSsml(text) };
+
+  const { data } = await axios.post(
+    url,
+    payload,
+    {
+      headers: {
+        "xi-api-key": apiKey,
+        "Content-Type": "application/json",
+        Accept: "audio/mpeg",
+      },
+      responseType: "arraybuffer",
     },
-    audioConfig: { audioEncoding: "MP3", speakingRate: 1.0 },
-  });
+  );
 
   // 2) Upload to GCS
   const objectName = `audio/${filename}.mp3`;
   const file = storage.bucket(BUCKET).file(objectName);
-  await file.save(response.audioContent, {
+  await file.save(data, {
     contentType: "audio/mpeg",
     public: true,
     metadata: { cacheControl: "public, max-age=31536000" },


### PR DESCRIPTION
## Summary
- swap the Google TTS client for ElevenLabs using axios
- remove `@google-cloud/text-to-speech` and install `axios`
- adjust `index.js` calls to the updated `synthesizeIndianEnglish`
- document new ElevenLabs variables in `.env.example`
- strip SSML tags before sending to ElevenLabs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840b980677c8321b8fd19efaa6ddc13