### PR TITLE
Switch to ElevenLabs TTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment configuration
+PORT=3000
+BASE_URL=http://localhost:3000
+GROQ_API_KEY=your-groq-key
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your-twilio-auth-token
+TWILIO_PHONE_NUMBER=+11234567890
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+ELEVENLABS_API_KEY=your-elevenlabs-api-key
+ELEVENLABS_VOICE_ID=voice-id

--- a/aiService.js
+++ b/aiService.js
@@ -20,15 +20,16 @@ const sessions = new Map();
 function initSession(sessionId, { name, description, topic }) {
   const sysPrompt = `
 You are a warm, friendly call-center assistant from Delhi.
-On your **first reply only**, deliver a natural, conversational **1-minute monologue** in English, peppered with everyday Delhi slang and genuine emotion—no robotic tags.
-Wrap your entire answer in a single SSML <speak>…</speak> tag.  
-If you need a pause, use a brief <break time="500ms"/>.  
-After the first monologue, switch to normal back-and-forth SSML responses.
+Your entire conversation should be in **Hindi**.
+On your **first reply only**, deliver a natural, conversational **1-minute monologue** in Hindi, peppered with everyday Delhi slang and genuine emotion—no robotic tags.
+Wrap your entire answer in a single SSML <speak>…</speak> tag.
+If you need a pause, use a brief <break time="500ms"/>.
+After the first monologue, continue with normal back-and-forth SSML responses in Hindi.
 
 When you want to end the call, invoke the "hangup" tool after your final sentence. Do not speak the tool name aloud.
 
-Topic: ${topic}  
-Contact’s name: ${name}${description ? `, description: "${description}"` : ""}.  
+Topic: ${topic}
+Contact’s name: ${name}${description ? `, description: "${description}"` : ""}.
 Begin immediately with that one-minute monologue.
   `.trim();
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ app.get("/test-tts", async (req, res) => {
   const text =
     req.query.text ||
     "नमस्ते, यह एक पूर्ण परीक्षण संदेश है ताकि आप सुन सकें कि आवाज़ कैसी निकलती है।";
-  const url = await synthesizeIndianEnglish(text, "test-tts", false);
+  const url = await synthesizeIndianEnglish(text, "test-tts");
   res.json({ url });
 });
 
@@ -32,7 +32,7 @@ app.get("/test-ssml", async (req, res) => {
   const sessionId = "TEST";
   initSession(sessionId, { name: "Test User", description: "Demo" });
   const { ssml } = await handleUserMessage(sessionId, "");
-  const url = await synthesizeIndianEnglish(ssml, "test-ssml", true);
+  const url = await synthesizeIndianEnglish(ssml, "test-ssml");
   endSession(sessionId);
   res.json({ url });
 });
@@ -48,8 +48,7 @@ app.post(
 
     try {
       let resp,
-        content,
-        isSsml = false;
+        content;
       if (!SpeechResult) {
         const contact = await prisma.contact.findUnique({
           where: { phone: To },
@@ -60,11 +59,9 @@ app.post(
         });
         resp = await handleUserMessage(CallSid, "");
         content = resp.ssml;
-        isSsml = true;
       } else {
         resp = await handleUserMessage(CallSid, SpeechResult);
         content = resp.ssml;
-        isSsml = content.trim().startsWith("<speak>");
       }
 
       const shouldHangup = resp.toolCalls.some((c) => c.name === "hangup");
@@ -73,7 +70,6 @@ app.post(
       const audioUrl = await synthesizeIndianEnglish(
         content,
         `${CallSid}_${SpeechResult ? "resp" : "greet"}`,
-        isSsml,
       );
 
       // === NEW: allow barge-in during playback ===

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/storage": "^7.16.0",
-        "@google-cloud/text-to-speech": "^6.1.0",
+        "axios": "^1.9.0",
         "@langchain/groq": "^0.2.2",
         "@prisma/client": "^6.8.1",
         "dotenv": "^16.5.0",
@@ -262,20 +262,8 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@google-cloud/text-to-speech": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/text-to-speech/-/text-to-speech-6.1.0.tgz",
-      "integrity": "sha512-QP8ESj0/QWyWDVI2wD0azoToxeBJ86IENajTTxgWkSXAki474qwv4hZgt5AHCtMJWHmWG5OnVNHzah5+zfbTlg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-gax": "^5.0.1-rc.0"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
+    
     "node_modules/@grpc/grpc-js": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
@@ -350,9 +338,6 @@
         "groq-sdk": "^0.19.0",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.22.5"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "peerDependencies": {
         "@langchain/core": ">=0.2.21 <0.4.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "type": "commonjs",
   "dependencies": {
     "@google-cloud/storage": "^7.16.0",
-    "@google-cloud/text-to-speech": "^6.1.0",
+    "axios": "^1.9.0",
     "@langchain/groq": "^0.2.2",
     "@prisma/client": "^6.8.1",
     "dotenv": "^16.5.0",


### PR DESCRIPTION
## Summary
- swap the Google TTS client for ElevenLabs using axios
- remove `@google-cloud/text-to-speech` and install `axios`
- adjust `index.js` calls to the updated `synthesizeIndianEnglish`
- document new ElevenLabs variables in `.env.example`
- instruct the assistant to converse in Hindi
- surface ElevenLabs API errors clearly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840b980677c8321b8fd19efaa6ddc13